### PR TITLE
[WIP] Reset ecx on posix 64

### DIFF
--- a/cpuid.py
+++ b/cpuid.py
@@ -25,6 +25,7 @@ from ctypes import c_uint32, c_int, c_size_t, c_void_p, POINTER, CFUNCTYPE
 _POSIX_64_OPC = [
         0x53,                    # push   %rbx
         0x48, 0x89, 0xf0,        # mov    %rsi,%rax
+        0x31, 0xc9,              # xor    %ecx,%ecx
         0x0f, 0xa2,              # cpuid
         0x89, 0x07,              # mov    %eax,(%rdi)
         0x89, 0x5f, 0x04,        # mov    %ebx,0x4(%rdi)

--- a/example.py
+++ b/example.py
@@ -40,4 +40,5 @@ if __name__ == "__main__":
     print("SSE4a     : %s" % is_set(cpu, 0x80000001, 2, 6))
     print("AVX       : %s" % is_set(cpu, 1, 2, 28))
     print("AVX2      : %s" % is_set(cpu, 7, 1, 5))
+    print("BMI2      : %s" % is_set(cpu, 7, 1, 8))
 


### PR DESCRIPTION
This fixes it on my 64bit Linux machine. Also added another feature check to `example.py`. I can try to figure it out on Windows, later. I don't think I have a 32bit CPU to test.

Edit: New output:

```
CPUID    A        B        C        D
00000000 00000014 756e6547 6c65746e 49656e69
00000001 000306d4 01100800 7ffafbbf bfebfbff
00000002 76036301 00f0b5ff 00000000 00c30000
00000003 00000000 00000000 00000000 00000000
00000004 1c004121 01c0003f 0000003f 00000000
00000005 00000040 00000040 00000003 11142120
00000006 00000077 00000002 00000009 00000000
00000007 00000000 021c27ab 00000000 00000000  <-- Yay :)
00000008 00000000 00000000 00000000 00000000
00000009 00000000 00000000 00000000 00000000
0000000a 07300403 00000000 00000000 00000603
0000000b 00000001 00000002 00000100 00000001
0000000c 00000000 00000001 00000001 00000000
0000000d 00000007 00000340 00000340 00000000
0000000e 00000000 00000000 00000000 00000000
0000000f 00000000 00000000 00000000 00000000
00000010 00000000 00000000 00000000 00000000
00000011 00000000 00000000 00000000 00000000
00000012 00000000 00000000 00000000 00000000
00000013 00000000 00000000 00000000 00000000
00000014 00000000 00000001 00000001 00000000
80000000 80000008 00000000 00000000 00000000
80000001 00000000 00000000 00000121 2c100800
80000002 65746e49 2952286c 726f4320 4d542865
80000003 37692029 3035352d 43205530 40205550
80000004 342e3220 7a484730 00000000 00000000
80000005 00000000 00000000 00000000 00000000
80000006 00000000 00000000 01006040 00000000
80000007 00000000 00000000 00000000 00000100
80000008 00003027 00000000 00000000 00000000
```
