### PR TITLE
Declare VirtualAlloc signature

### DIFF
--- a/cpuid.py
+++ b/cpuid.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 import platform
 import os
 import ctypes
-from ctypes import c_uint32, c_int, c_size_t, c_void_p, POINTER, CFUNCTYPE
+from ctypes import c_uint32, c_int, c_long, c_ulong, c_size_t, c_void_p, POINTER, CFUNCTYPE
 
 # Posix x86_64:
 # Two first call registers : RDI, RSI
@@ -98,6 +98,8 @@ class CPUID(object):
         self.r = CPUID_struct()
 
         if is_windows:
+            self.win.VirtualAlloc.restype = c_void_p
+            self.win.VirtualAlloc.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_ulong, ctypes.c_ulong]
             self.addr = self.win.VirtualAlloc(None, size, 0x1000, 0x40)
             if not self.addr:
                 raise MemoryError("Could not allocate RWX memory")
@@ -126,6 +128,8 @@ class CPUID(object):
 
     def __del__(self):
         if is_windows:
+            self.win.VirtualFree.restype = c_long
+            self.win.VirtualFree.argtypes = [c_void_p, c_size_t, c_ulong]
             self.win.VirtualFree(self.addr, 0, 0x8000)
         elif ctypes.pythonapi:
             # Seems to throw exception when the program ends and


### PR DESCRIPTION
VirtualAlloc fails without an explicit signature on Windows 10, x86-64 with 64 bit Python 3.6:

````
>python cpuid.py
CPUID    A        B        C        D
Traceback (most recent call last):
  File "cpuid.py", line 148, in <module>
    for eax, regs in valid_inputs():
  File "cpuid.py", line 139, in valid_inputs
    cpuid = CPUID()
  File "cpuid.py", line 118, in __init__
    ctypes.memmove(self.addr, code, size)
OSError: exception: access violation writing 0x000000007D470000
``````

Similarly, VirtualFree fails without an explicit signature:

```
>python cpuid.py
CPUID    A        B        C        D
00000000 00000014 756e6547 6c65746e 49656e69
00000001 000406f1 04100800 7ffefbbf bfebfbff
00000002 76036301 00f0b5ff 00000000 00c30000
00000003 00000000 00000000 00000000 00000000
00000004 1c004121 01c0003f 0000003f 00000000
00000005 00000040 00000040 00000003 00002120
00000006 00000077 00000002 00000009 00000000
00000007 00000000 021cbfbb 00000000 00000000
00000008 00000000 00000000 00000000 00000000
00000009 00000001 00000000 00000000 00000000
0000000a 07300403 00000000 00000000 00000603
0000000b 00000001 00000002 00000100 00000000
0000000c 00000000 00000000 00000000 00000000
0000000d 00000007 00000340 00000340 00000000
0000000e 00000000 00000000 00000000 00000000
0000000f 00000000 0000002f 00000000 00000002
00000010 00000000 00000002 00000000 00000000
00000011 00000000 00000000 00000000 00000000
00000012 00000000 00000000 00000000 00000000
00000013 00000000 00000000 00000000 00000000
00000014 00000000 00000001 00000001 00000000
80000000 80000008 00000000 00000000 00000000
80000001 00000000 00000000 00000121 2c100800
80000002 65746e49 2952286c 726f4320 4d542865
80000003 37692029 3538362d 43204b30 40205550
80000004 362e3320 7a484730 00000000 00000000
80000005 00000000 00000000 00000000 00000000
80000006 00000000 00000000 01006040 00000000
80000007 00000000 00000000 00000000 00000100
80000008 0000302e 00000000 00000000 00000000
Exception ignored in: <bound method CPUID.__del__ of <__main__.CPUID object at 0x000001B55E4F1748>>
Traceback (most recent call last):
  File "cpuid.py", line 131, in __del__
    self.win.VirtualFree(self.addr, 0, 0x8000)
ctypes.ArgumentError: argument 1: <class 'OverflowError'>: int too long to convert
```

Found and fixed first here: https://github.com/niklasf/fishnet/issues/80