### PR TITLE
Allow returning a structure with all registers

### DIFF
--- a/cpuid.py
+++ b/cpuid.py
@@ -114,12 +114,17 @@ class CPUID(object):
         func_type = CFUNCTYPE(None, POINTER(CPUID_struct), c_uint32, c_uint32)
         self.func_ptr = func_type(self.addr)
 
-    def __call__(self, eax, ecx=0, unpack=True):
+    def __call__(self, eax, ecx=0):
+        struct = self.registers_for(eax=eax, ecx=ecx)
+        return struct.eax, struct.ebx, struct.ecx, struct.edx
+
+    def registers_for(self, eax, ecx):
+        """Calls cpuid with eax and ecx set as the input arguments, and returns a structure
+        containing eax, ebx, ecx, and edx.
+        """
         struct = CPUID_struct()
         self.func_ptr(struct, eax, ecx)
-        if not unpack:
-            return struct
-        return struct.eax, struct.ebx, struct.ecx, struct.edx
+        return struct
 
     def __del__(self):
         if is_windows:

--- a/cpuid.py
+++ b/cpuid.py
@@ -114,9 +114,11 @@ class CPUID(object):
         func_type = CFUNCTYPE(None, POINTER(CPUID_struct), c_uint32, c_uint32)
         self.func_ptr = func_type(self.addr)
 
-    def __call__(self, eax, ecx=0):
+    def __call__(self, eax, ecx=0, unpack=True):
         struct = CPUID_struct()
         self.func_ptr(struct, eax, ecx)
+        if not unpack:
+            return struct
         return struct.eax, struct.ebx, struct.ecx, struct.edx
 
     def __del__(self):


### PR DESCRIPTION
This is just a convenience to retrieve and test results from a single call.