### PR TITLE
add i86pc identifier

### DIFF
--- a/cpuid.py
+++ b/cpuid.py
@@ -84,7 +84,7 @@ class CPUID_struct(ctypes.Structure):
 
 class CPUID(object):
     def __init__(self):
-        if platform.machine() not in ("AMD64", "x86_64", "x86", "i686"):
+        if platform.machine() not in ("AMD64", "x86_64", "x86", "i686", "i86pc"):
             raise SystemError("Only available for x86")
 
         if is_windows:


### PR DESCRIPTION
CPython on illumos and SunOS reports platform.machine() as i86pc (on 64-bit host).